### PR TITLE
use list constructors for query.t

### DIFF
--- a/bench/bench_ecs.ml
+++ b/bench/bench_ecs.ml
@@ -46,7 +46,7 @@ let t3 =
       fun () ->
         let results =
           World.query world
-            Query.(Req (module Foo.C) @ Req (module Bar.C) @ Nil)
+            Query.[Req (module Foo.C); Req (module Bar.C)]
         in
         assert (List.length results = param))
 

--- a/examples/bounce.ml
+++ b/examples/bounce.ml
@@ -31,7 +31,7 @@ end
 let simulate_ball =
   let query w =
     let _, (t, (b, ())) =
-      World.query w Query.(Req (module Transform.C) @ Req (module Ball.C) @ Nil)
+      World.query w Query.[Req (module Transform.C); Req (module Ball.C)]
       |> List.hd
     in
     (t, b)
@@ -58,10 +58,10 @@ let simulate_ball =
 let restart_ball =
   let query w =
     let _, (k, ()) =
-      World.query w Query.(Req (module Input.Keyboard.C) @ Nil) |> List.hd
+      World.query w Query.[Req (module Input.Keyboard.C)] |> List.hd
     in
     let _, (t, (b, ())) =
-      World.query w Query.(Req (module Transform.C) @ Req (module Ball.C) @ Nil)
+      World.query w Query.[Req (module Transform.C); Req (module Ball.C)]
       |> List.hd
     in
     (k, t, b)
@@ -77,16 +77,16 @@ let restart_ball =
 let camera_follow_ball =
   let query w =
     let _, (k, ()) =
-      World.query w Query.(Req (module Input.Keyboard.C) @ Nil) |> List.hd
+      World.query w Query.[Req (module Input.Keyboard.C)] |> List.hd
     in
     let _, (ball_t, ()) =
       World.query ~filter:(Query.Filter.With Ball.C.id) w
-        Query.(Req (module Transform.C) @ Nil)
+        Query.[Req (module Transform.C)]
       |> List.hd
     in
     let _, (camera_t, ()) =
       World.query ~filter:(Query.Filter.With Graphics.Camera3d.C.id) w
-        Query.(Req (module Transform.C) @ Nil)
+        Query.[Req (module Transform.C)]
       |> List.hd
     in
     (k, ball_t, camera_t)

--- a/examples/disco.ml
+++ b/examples/disco.ml
@@ -96,7 +96,7 @@ let spawn_ground w =
 let spin =
   let query w =
     World.query ~filter:(Query.Filter.With Spin.C.id) w
-      Query.(Req (module Transform.C) @ Nil)
+      Query.[Req (module Transform.C)]
     |> List.map (fun (_, (t, ())) -> t)
   in
   let spin =
@@ -112,7 +112,7 @@ let update_disco_balls =
   let open Graphics in
   let query w =
     World.query w
-      Query.(Req (module Light.Point.C) @ Req (module Disco_ball.C) @ Nil)
+      Query.[Req (module Light.Point.C); Req (module Disco_ball.C)]
     |> List.map (fun (_, (p, (db, ()))) -> (p, db))
   in
   let dim_color color =

--- a/examples/game_of_life.ml
+++ b/examples/game_of_life.ml
@@ -92,11 +92,11 @@ end
 let step =
   let query w =
     let _, (keyboard, ()) =
-      World.query w Query.(Req (module Input.Keyboard.C) @ Nil) |> List.hd
+      World.query w Query.[Req (module Input.Keyboard.C)] |> List.hd
     in
     let _, (grid, (mesh, ())) =
       World.query w
-        Query.(Req (module Grid.C) @ Req (module Graphics.Mesh3d.C) @ Nil)
+        Query.[Req (module Grid.C); Req (module Graphics.Mesh3d.C)]
       |> List.hd
     in
     (keyboard, grid, mesh)

--- a/examples/move.ml
+++ b/examples/move.ml
@@ -15,11 +15,11 @@ let move_ball =
   let query w =
     let transforms =
       World.query ~filter:(Query.Filter.With Ball.C.id) w
-        Query.(Req (module Transform.C) @ Nil)
+        Query.[Req (module Transform.C)]
       |> List.map (fun (_, (t, ())) -> t)
     in
     let _, (k, ()) =
-      World.query w Query.(Req (module Input.Keyboard.C) @ Nil) |> List.hd
+      World.query w Query.[Req (module Input.Keyboard.C)] |> List.hd
     in
     (transforms, k)
   in

--- a/examples/plugin/fp_camera.ml
+++ b/examples/plugin/fp_camera.ml
@@ -8,11 +8,11 @@ let handle_keyboard factor =
   let query w =
     let transforms =
       World.query ~filter:(Query.Filter.With C.id) w
-        Query.(Req (module Transform.C) @ Nil)
+        Query.[Req (module Transform.C)]
       |> List.map (fun (_, (t, ())) -> t)
     in
     let k =
-      World.query w Query.(Req (module Input.Keyboard.C) @ Nil)
+      World.query w Query.[Req (module Input.Keyboard.C)]
       |> List.map (fun (_, (k, ())) -> k)
     in
     (transforms, match k with k :: _ -> Some k | _ -> None)
@@ -65,11 +65,11 @@ let handle_mouse sensitivity =
   let query w =
     let transforms =
       World.query ~filter:(Query.Filter.With C.id) w
-        Query.(Req (module Transform.C) @ Nil)
+        Query.[Req (module Transform.C)]
       |> List.map (fun (_, (t, ())) -> t)
     in
     let mm =
-      World.query w Query.(Req (module Input.Mouse.Motion_event.C) @ Nil)
+      World.query w Query.[Req (module Input.Mouse.Motion_event.C)]
       |> List.map (fun (_, (mm, ())) -> mm)
     in
     (transforms, match mm with mm :: _ -> Some mm | _ -> None)
@@ -101,7 +101,7 @@ let handle_mouse sensitivity =
 let set_fullscreen =
   System.make
     (fun w ->
-      World.query w Query.(Req (module Graphics.Context.C) @ Nil)
+      World.query w Query.[Req (module Graphics.Context.C)]
       |> List.map (fun (_, (c, ())) -> c))
     (System.Query
        (List.iter (fun context ->

--- a/examples/shapes.ml
+++ b/examples/shapes.ml
@@ -16,7 +16,7 @@ let rotate =
   let query w =
     let transforms =
       World.query ~filter:(Query.Filter.With Shape.C.id) w
-        Query.(Req (module Transform.C) @ Nil)
+        Query.[Req (module Transform.C)]
       |> List.map (fun (_, (t, ())) -> t)
     in
     transforms

--- a/examples/spawn.ml
+++ b/examples/spawn.ml
@@ -26,7 +26,7 @@ let add_random_ball w =
 let handle_spawn =
   let query w =
     let _, (mb, ()) =
-      World.query w Query.(Req (module Input.Mouse.Button.C) @ Nil) |> List.hd
+      World.query w Query.[Req (module Input.Mouse.Button.C)] |> List.hd
     in
     mb
   in

--- a/lib/ecs/event.ml
+++ b/lib/ecs/event.ml
@@ -29,7 +29,7 @@ end) : S with type event = B.t = struct
   end)
 
   let querier w =
-    let _, (t, ()) = World.query w Query.(Req (module C) @ Nil) |> List.hd in
+    let _, (t, ()) = World.query w Query.[Req (module C)] |> List.hd in
     t
 
   let clear_system =

--- a/lib/ecs/query.mli
+++ b/lib/ecs/query.mli
@@ -22,7 +22,7 @@ type 'a term =
       (** An optional component will be None if an entity does not have it. *)
 
 (** The type of a query. *)
-type 'a t = Nil : unit t | Cons : 'a term * 'b t -> ('a * 'b) t
+type 'a t = [] : unit t | (::) : 'a term * 'b t -> ('a * 'b) t
 
 val required_ids : 'a t -> Id.ComponentSet.t
 (** Returns the set of required component IDs for the given query. *)
@@ -30,6 +30,3 @@ val required_ids : 'a t -> Id.ComponentSet.t
 val evaluate :
   ?filter:Filter.t -> 'a t -> Archetype.t list -> (Id.Entity.t * 'a) list
 (** Evaluates the given query on the given archetypes. *)
-
-val ( @ ) : 'a term -> 'b t -> ('a * 'b) t
-(** Composes query terms. *)

--- a/lib/graphics/graphics.ml
+++ b/lib/graphics/graphics.ml
@@ -16,7 +16,7 @@ let initialize ~gl =
     (fun w ->
       let open Ecs in
       let _, (c, ()) =
-        World.query w Query.(Req (module Context.C) @ Nil) |> List.hd
+        World.query w Query.[Req (module Context.C)] |> List.hd
       in
       c)
     (Ecs.System.Query
@@ -31,7 +31,7 @@ let render =
     (fun w ->
       let open Ecs in
       let _, (c, ()) =
-        World.query w Query.(Req (module Context.C) @ Nil) |> List.hd
+        World.query w Query.[Req (module Context.C)] |> List.hd
       in
       c)
     (Ecs.System.Query
@@ -45,8 +45,8 @@ let handle_events =
   Ecs.System.make
     (fun w ->
       let open Ecs in
-      let c = World.query w Query.(Req (module Context.C) @ Nil) in
-      let we = World.query w Query.(Req (module Input.Window_event.C) @ Nil) in
+      let c = World.query w Query.[Req (module Context.C)] in
+      let we = World.query w Query.[Req (module Input.Window_event.C)] in
       ( List.nth_opt c 0 |> Option.map (fun (_, (c, ())) -> c),
         List.nth_opt we 0 |> Option.map (fun (_, (we, ())) -> we) ))
     (Ecs.System.Query
@@ -78,9 +78,9 @@ let cleanup =
     (fun w ->
       let open Ecs in
       let c_entity, (c, ()) =
-        World.query w Query.(Req (module Context.C) @ Nil) |> List.hd
+        World.query w Query.[Req (module Context.C)] |> List.hd
       in
-      let m3d = World.query w Query.(Req (module Mesh3d.C) @ Nil) in
+      let m3d = World.query w Query.[Req (module Mesh3d.C)] in
       (c_entity, c, List.map (fun (_, (m3d, ())) -> m3d) m3d))
     (Ecs.System.Immediate
        (fun w ->

--- a/lib/graphics/shader/normal.ml
+++ b/lib/graphics/shader/normal.ml
@@ -33,11 +33,11 @@ let query w =
   let open Ecs in
   let cameras =
     World.query ~filter:(Query.Filter.With Camera.Camera3d.C.id) w
-      Query.(Req (module Camera.Projection.C) @ Opt (module Transform.C) @ Nil)
+      Query.[Req (module Camera.Projection.C); Opt (module Transform.C)]
   in
   let entities =
     World.query ~filter:(Query.Filter.With C.id) w
-      Query.(Req (module Mesh3d.C) @ Opt (module Transform.C) @ Nil)
+      Query.[Req (module Mesh3d.C); Opt (module Transform.C)]
   in
   ( List.map (fun (_, (c, (t, ()))) -> (c, t)) cameras,
     List.map (fun (_, (m, (t, ()))) -> (m, t)) entities )

--- a/lib/graphics/shader/phong.ml
+++ b/lib/graphics/shader/phong.ml
@@ -147,17 +147,13 @@ let query w =
   let open Ecs in
   let cameras =
     World.query ~filter:(Query.Filter.With Camera.Camera3d.C.id) w
-      Query.(Req (module Camera.Projection.C) @ Opt (module Transform.C) @ Nil)
+      Query.[Req (module Camera.Projection.C); Opt (module Transform.C)]
     |> List.map (fun (_, (p, (t, ()))) -> (p, t))
   in
 
   let entities =
     World.query w ~filter:(Query.Filter.With C.id)
-      Query.(
-        Req (module Mesh3d.C)
-        @ Req (module Material.C)
-        @ Opt (module Transform.C)
-        @ Nil)
+      Query.[Req (module Mesh3d.C); Req (module Material.C); Opt (module Transform.C)]
     |> List.map (fun (_, (m3d, (m, (t, ())))) -> (m3d, m, t))
   in
   let parse_lights l =
@@ -166,17 +162,17 @@ let query w =
 
   let point_lights =
     World.query w
-      Query.(Req (module Light.Point.C) @ Opt (module Transform.C) @ Nil)
+      Query.[Req (module Light.Point.C); Opt (module Transform.C)]
     |> parse_lights
   in
   let directional_lights =
     World.query w
-      Query.(Req (module Light.Directional.C) @ Opt (module Transform.C) @ Nil)
+      Query.[Req (module Light.Directional.C); Opt (module Transform.C)]
     |> parse_lights
   in
   let spot_lights =
     World.query w
-      Query.(Req (module Light.Spot.C) @ Opt (module Transform.C) @ Nil)
+      Query.[Req (module Light.Spot.C); Opt (module Transform.C)]
     |> parse_lights
   in
   { cameras; entities; point_lights; directional_lights; spot_lights }

--- a/lib/input/button_state.ml
+++ b/lib/input/button_state.ml
@@ -58,10 +58,10 @@ module Make (B : Button.S) (E : Ecs.Event.S with type event = B.t) :
     let query w =
       let open Ecs in
       let _, (event, ()) =
-        World.query w Query.(Req (module E.C) @ Nil) |> List.hd
+        World.query w Query.[Req (module E.C)] |> List.hd
       in
       let _, (state, ()) =
-        World.query w Query.(Req (module C) @ Nil) |> List.hd
+        World.query w Query.[Req (module C)] |> List.hd
       in
       (event, state)
     in

--- a/lib/input/input.ml
+++ b/lib/input/input.ml
@@ -33,16 +33,16 @@ let write_events =
   let query w =
     let open Ecs in
     let _, (ke, ()) =
-      World.query w Query.(Req (module Key_event.C) @ Nil) |> List.hd
+      World.query w Query.[Req (module Key_event.C)] |> List.hd
     in
     let _, (we, ()) =
-      World.query w Query.(Req (module Window_event.C) @ Nil) |> List.hd
+      World.query w Query.[Req (module Window_event.C)] |> List.hd
     in
     let _, (mb, ()) =
-      World.query w Query.(Req (module Mouse.Button_event.C) @ Nil) |> List.hd
+      World.query w Query.[Req (module Mouse.Button_event.C)] |> List.hd
     in
     let _, (mm, ()) =
-      World.query w Query.(Req (module Mouse.Motion_event.C) @ Nil) |> List.hd
+      World.query w Query.[Req (module Mouse.Motion_event.C)] |> List.hd
     in
     (ke, we, mb, mm)
   in

--- a/test/ecs/test_query.ml
+++ b/test/ecs/test_query.ml
@@ -35,18 +35,18 @@ let test_required_components () =
   let required_eq q l =
     Id.ComponentSet.equal (required_ids q) (Id.ComponentSet.of_list l)
   in
-  let q = Nil in
+  let q = [] in
   assert (required_eq q []);
-  let q = Req (module Foo.C) @ Nil in
+  let q = Req (module Foo.C) :: [] in
   assert (required_eq q [ Foo.C.id ]);
 
-  let q = Req (module Foo.C) @ Opt (module Bar.C) @ Nil in
+  let q = Req (module Foo.C) :: Opt (module Bar.C) :: [] in
   assert (required_eq q [ Foo.C.id ]);
 
-  let q = Opt (module Bar.C) @ Opt (module Baz.C) @ Nil in
+  let q = Opt (module Bar.C) :: Opt (module Baz.C) :: [] in
   assert (required_eq q []);
 
-  let q = Req (module Foo.C) @ Opt (module Baz.C) @ Req (module Bar.C) @ Nil in
+  let q = Req (module Foo.C) :: Opt (module Baz.C) :: Req (module Bar.C) :: [] in
   assert (required_eq q [ Foo.C.id; Bar.C.id ])
 
 let test_evaluate () =


### PR DESCRIPTION
hiya

so in your blog post you mnention

> The downside is that we end up with nested tuples like (t, (b, ())), and we must remember to terminate the query with Nil.

this PR addresses the second point here: no need for `Nil` and a more pleasant syntax

it's based on the fact that the OCaml compiler treats the list syntactic sugar (`[`-`;`-`]`) like constructors (`::`-`[]`) even when the constructors are for a custom type

PS: i think it's possible to address the first point and avoid the nested tuple by accumulating the types as a list and then have some kind of `query_apply` which takes a query and a function to apply to the matches

PPS: more details on the tricks: https://raphael-proust.gitlab.io/code/gadt-tips-and-tricks.html